### PR TITLE
Auto-detect ChromeDriver location and version from System's PATH.

### DIFF
--- a/dev/tests/acceptance/pre-install.php
+++ b/dev/tests/acceptance/pre-install.php
@@ -197,9 +197,15 @@ class PreInstallCheck {
         $this->seleniumFilePath = fgets($handle2);
         fclose($handle2);
 
+        if ($this->chromeFilePath = $this->getChromeDriverPath()) {
+            ECHO sprintf("ChromeDriver (ver. %s) detected in: %s", $this->parseVersion($this->getChromeDriverVersion()), $this->chromeFilePath);
+            ECHO "You can override this path below (leave empty to use detected one).\n";
+        }
         ECHO "Provide absolute path to chromedriver: ";
         $handle3 = fopen ("php://stdin","r");
-        $this->chromeFilePath = fgets($handle3);
+        if ($newChromeFilePath = trim(fgets($handle3))) {
+            $this->chromeFilePath = $newChromeFilePath;
+        }
         fclose($handle3);
         ECHO "\n";
     }
@@ -257,6 +263,15 @@ class PreInstallCheck {
                 $this->getSeleniumVersion = trim($vals[1]);
             }
         });
+    }
+
+    /**
+     * @return string
+     */
+    private function getChromeDriverPath()
+    {
+        $command = 'which chromedriver';
+        return shell_exec($command);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
As discussed with @imeron2433 during MageTestFest, I've added extra detection method for ChromeDriver which will automatically get path of ChromeDriver executable if it's installed globally on the system (eg. ansible-provisioned machines).

<img width="609" alt="zrzut ekranu 2017-11-19 o 10 59 58" src="https://user-images.githubusercontent.com/1639941/32989550-d4f12f2c-cd18-11e7-90c5-907e94b47c3e.png">


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install ChromeDriver globally
2. Run `vendor/bin/robo pre:install`
3. Expect information `ChromeDriver (ver. 2.33.506092) detected in: /usr/bin/chromedriver` before asking ChromeDriver path.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
